### PR TITLE
Added Layouts folder to purge directory for postCSS in TailwindCSS...

### DIFF
--- a/tailwind.config.js
+++ b/tailwind.config.js
@@ -1,5 +1,5 @@
 module.exports = {
-    purge: ['./pages/**/*.js', './components/**/*.js'],
+    purge: ['./pages/**/*.js', './components/**/*.js', './layouts/**/*.js'],
     darkMode: false, // or 'media' or 'class'
     theme: {
         extend: {},


### PR DESCRIPTION
 to prevent purging styles used only in layouts folder such as min-h-screen.

To verify the difference, you can run 'npm run build & npm run start' in the main branch to see the production version with all the white space under the navbar. And then run it again in this branch to see it is fixed. 